### PR TITLE
gha auto-publish to pypi and testpypi

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -42,8 +42,7 @@ jobs:
       url: https://pypi.org/p/csv-to-xlsx-report
 
     permissions:
-      contents: write
-      id-token: write
+#      id-token: write
 
     steps:
     - name: Download all the dists
@@ -66,8 +65,7 @@ jobs:
       url: https://test.pypi.org/p/csv-to-xlsx-report
 
     permissions:
-      contents: write
-      id-token: write
+#      id-token: write
 
     steps:
     - name: Download all the dists

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -78,3 +78,4 @@ jobs:
       with:
         verbose: true
         repository-url: https://test.pypi.org/legacy
+

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,79 @@
+name: Publish Python distribution to PyPI and TestPyPI
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/csv-to-xlsx-report
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-to-testpypi:
+    name: >-
+      Publish Python distribution to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/csv-to-xlsx-report
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -41,8 +41,8 @@ jobs:
       name: pypi
       url: https://pypi.org/p/csv-to-xlsx-report
 
-#    permissions:
-#      id-token: write
+   permissions:
+     id-token: write
 
     steps:
     - name: Download all the dists
@@ -64,8 +64,8 @@ jobs:
       name: testpypi
       url: https://test.pypi.org/p/csv-to-xlsx-report
 
-#    permissions:
-#      id-token: write
+   permissions:
+     id-token: write
 
     steps:
     - name: Download all the dists

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -77,5 +77,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         verbose: true
-        repository-url: https://test.pypi.org/legacy
-
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -41,8 +41,8 @@ jobs:
       name: pypi
       url: https://pypi.org/p/csv-to-xlsx-report
 
-   permissions:
-     id-token: write
+    permissions:
+      id-token: write
 
     steps:
     - name: Download all the dists
@@ -64,8 +64,8 @@ jobs:
       name: testpypi
       url: https://test.pypi.org/p/csv-to-xlsx-report
 
-   permissions:
-     id-token: write
+    permissions:
+      id-token: write
 
     steps:
     - name: Download all the dists

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -42,6 +42,7 @@ jobs:
       url: https://pypi.org/p/csv-to-xlsx-report
 
     permissions:
+      contents: write
       id-token: write
 
     steps:
@@ -65,6 +66,7 @@ jobs:
       url: https://test.pypi.org/p/csv-to-xlsx-report
 
     permissions:
+      contents: write
       id-token: write
 
     steps:
@@ -76,4 +78,5 @@ jobs:
     - name: Publish distribution to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
+        verbose: true
         repository-url: https://test.pypi.org/legacy

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -41,7 +41,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/csv-to-xlsx-report
 
-    permissions:
+#    permissions:
 #      id-token: write
 
     steps:
@@ -64,7 +64,7 @@ jobs:
       name: testpypi
       url: https://test.pypi.org/p/csv-to-xlsx-report
 
-    permissions:
+#    permissions:
 #      id-token: write
 
     steps:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ These versions are currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.0.1   | :white_check_mark: |
+| 0.0.3   | :white_check_mark: |
 
 ## Reporting a vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'hatchling.build'
 
 [project]
 name = 'csv_to_xlsx_report'
-version = '0.0.2'
+version = '0.0.3'
 dependencies = [
     'pandas >= 2.2.3',
     'xlsxwriter >= 3.2.3',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='csv_to_xlsx_report',
-    version='0.0.2',
+    version='0.0.3',
     packages=find_packages(include=['csv_to_xlsx_report.*']),
     install_requires=['pandas >= 2.2.3',
                       'xlsxwriter >= 3.2.3'],

--- a/src/csv_to_xlsx_report/csv_to_xlsx_report.py
+++ b/src/csv_to_xlsx_report/csv_to_xlsx_report.py
@@ -1,5 +1,3 @@
-# TO DO: Support encoding
-
 # Standard libraries
 import csv
 from string import ascii_uppercase


### PR DESCRIPTION
## Describe the change.
Enable auto-publishing to PyPI via GHA.
All pushes will auto-publish to TestPyPI.
All tagged pushes will auto-publish to PyPI.

## Provide a link to the related issue, if applicable.
n/a

## How to verify the change?
n/a

## Did you follow the contribution rules?
- Peer review required for major changes.
- Follow [PEP8 style](https://peps.python.org/pep-0008/).
- Lint with flake8.
- Use docstrings.
n/a